### PR TITLE
[Refactor] 지원서 페이지 임시저장 기능 추가를 위한 로컬 스토리지 저장

### DIFF
--- a/src/pages/apply-page.tsx
+++ b/src/pages/apply-page.tsx
@@ -1,6 +1,7 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { useQuery } from '@tanstack/react-query';
 
+import { clearDraft, loadDraft, saveDraft } from '@/widgets/apply/model/apply-draft';
 import { APPLY_QUERY_OPTIONS } from '@/widgets/apply/model/query-options';
 import { usePersonalInfoForm } from '@/widgets/apply/model/use-personal-info-form';
 import { useSubmitApplication } from '@/widgets/apply/model/use-submit-application';
@@ -19,13 +20,19 @@ const STEPS = ['지원자 정보', '공통 질문', '부문 질문'] as const;
 const LAST_STEP = STEPS.length - 1;
 
 const ApplyPage = () => {
-  const [currentStep, setCurrentStep] = useState(0);
-  const [answers, setAnswers] = useState<Record<string, string>>({});
+  const [draft] = useState(loadDraft);
+  const [currentStep, setCurrentStep] = useState(draft?.step ?? 0);
+  const [answers, setAnswers] = useState<Record<string, string>>(draft?.answers ?? {});
 
   const { data: deadline } = useRecruitmentDeadline();
   const recruitmentId = deadline?.recruitment_id ?? 0;
 
-  const personalInfo = usePersonalInfoForm();
+  const personalInfo = usePersonalInfoForm(draft?.personalInfo);
+
+  useEffect(() => {
+    saveDraft({ step: currentStep, personalInfo: personalInfo.form, answers });
+  }, [currentStep, personalInfo.form, answers]);
+
   const { form } = personalInfo;
   const track = form.track;
 
@@ -72,11 +79,14 @@ const ApplyPage = () => {
 
   const handleSubmit = () => {
     const personalPayload = personalInfo.toApiPayload();
-    submitMutation.mutate({
-      ...personalPayload,
-      recruitment_id: recruitmentId,
-      answers: buildAnswers(),
-    } as ApplicationRequest);
+    submitMutation.mutate(
+      {
+        ...personalPayload,
+        recruitment_id: recruitmentId,
+        answers: buildAnswers(),
+      } as ApplicationRequest,
+      { onSuccess: clearDraft }
+    );
   };
 
   const trackSectionProps = {

--- a/src/widgets/apply/model/apply-draft.ts
+++ b/src/widgets/apply/model/apply-draft.ts
@@ -1,0 +1,30 @@
+import type { PersonalInfoForm } from './use-personal-info-form';
+
+const DRAFT_KEY = 'boaz-apply-draft';
+
+export interface ApplyDraft {
+  step: number;
+  personalInfo: PersonalInfoForm;
+  answers: Record<string, string>;
+}
+
+export const loadDraft = (): ApplyDraft | null => {
+  try {
+    const raw = localStorage.getItem(DRAFT_KEY);
+    return raw ? (JSON.parse(raw) as ApplyDraft) : null;
+  } catch {
+    return null;
+  }
+};
+
+export const saveDraft = (draft: ApplyDraft): void => {
+  try {
+    localStorage.setItem(DRAFT_KEY, JSON.stringify(draft));
+  } catch {
+    // 예외 상황 무시
+  }
+};
+
+export const clearDraft = (): void => {
+  localStorage.removeItem(DRAFT_KEY);
+};

--- a/src/widgets/apply/model/use-personal-info-form.ts
+++ b/src/widgets/apply/model/use-personal-info-form.ts
@@ -3,7 +3,7 @@ import { useState } from 'react';
 import { ACADEMIC_GRADES, MONTHS, SEMESTERS } from '@/widgets/apply/apply-dropdown';
 import type { MilitaryStatus, Track } from '@/shared/api/types';
 
-interface PersonalInfoForm {
+export interface PersonalInfoForm {
   track: Track | null;
   name: string;
   birthYear: string;
@@ -50,8 +50,8 @@ const computeLastSemester = (grade: string, semester: string): number => {
 const stripKoreanUnit = (value: string): string => value.replace(/[년월일]/g, '').trim();
 const padTwo = (n: number): string => String(n).padStart(2, '0');
 
-export const usePersonalInfoForm = () => {
-  const [form, setForm] = useState<PersonalInfoForm>(INITIAL_FORM);
+export const usePersonalInfoForm = (initialForm?: PersonalInfoForm) => {
+  const [form, setForm] = useState<PersonalInfoForm>(initialForm ?? INITIAL_FORM);
 
   const setField = <K extends keyof PersonalInfoForm>(field: K, value: PersonalInfoForm[K]) =>
     setForm((prev) => ({ ...prev, [field]: value }));


### PR DESCRIPTION
## 📌 Summary

<!-- 관련 Issue를 태그해주세요 -->
<!-- #뒤에 이슈넘버 써주시면 자동으로 이슈페이지 연결이 됩니다 ! -->

- Resolves: #96 

## 📚 Tasks

<!-- 작업한 부분에 대한 내용을 써주세요 -->

- 지원서 작성 중 페이지를 이탈해도 입력 내용이 유지되도록 로컬 스토리지 임시저장 기능 구현

## 👀 To Reviewer

<!--
(기재 내용 없을 경우 섹션 삭제)
더 전달할 내용 혹은 리뷰에게 요청하는 내용을 작성해주세요.
-->

- `recruitmentId`는 draft에 포함하지 않았습니다. 모집 기간이 바뀌면 `answers`의 `questionId`가 새 질문 목록과 불일치할 수 있으나, 개인정보는 그대로 복원됩니다. 필요 시 추후 처리 가능합니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 신청 폼 작성 중 진행 상황과 입력 내용을 자동으로 저장합니다.
  * 창을 닫아도 이전에 작성한 내용이 유지되어 나중에 계속할 수 있습니다.
  * 신청 제출 완료 후 저장된 임시 내용이 자동으로 삭제됩니다.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/BOAZ-website/frontend/pull/97?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->