### PR TITLE
[Feat] 소셜 로그인 구현 및 ProtectedRoute 설정

### DIFF
--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -2,6 +2,7 @@ import { RouterProvider } from 'react-router-dom';
 
 import { QueryProvider } from '@/app/providers/query-provider';
 import { ThemeProvider } from '@/app/providers/theme-provider';
+import { AuthProvider } from '@/features/auth/model/auth-context';
 import { router } from '@/shared/router/router';
 
 import '@/shared/styles/reset.css';
@@ -11,7 +12,9 @@ function App() {
   return (
     <ThemeProvider>
       <QueryProvider>
-        <RouterProvider router={router} />
+        <AuthProvider>
+          <RouterProvider router={router} />
+        </AuthProvider>
       </QueryProvider>
     </ThemeProvider>
   );

--- a/src/features/auth/api/logout.ts
+++ b/src/features/auth/api/logout.ts
@@ -1,0 +1,6 @@
+import { instance } from '@/shared/api/client';
+import { END_POINT } from '@/shared/api/end-point';
+
+export const logoutApi = async (): Promise<void> => {
+  await instance.post(END_POINT.AUTH.LOGOUT);
+};

--- a/src/features/auth/api/refresh.ts
+++ b/src/features/auth/api/refresh.ts
@@ -1,0 +1,7 @@
+import { instance } from '@/shared/api/client';
+import { END_POINT } from '@/shared/api/end-point';
+
+export const refreshToken = async (): Promise<string> => {
+  const response = await instance.post<{ data: { access_token: string } }>(END_POINT.AUTH.REFRESH);
+  return response.data.data.access_token;
+};

--- a/src/features/auth/model/auth-context.tsx
+++ b/src/features/auth/model/auth-context.tsx
@@ -1,0 +1,39 @@
+import { createContext, useContext, useState } from 'react';
+import type { ReactNode } from 'react';
+
+import { tokenStorage } from '@/shared/auth/token-storage';
+
+interface AuthContextValue {
+  isLoggedIn: boolean;
+  login: (token: string) => void;
+  logout: () => void;
+}
+
+const AuthContext = createContext<AuthContextValue | null>(null);
+
+export const AuthProvider = ({ children }: { children: ReactNode }) => {
+  const [isLoggedIn, setIsLoggedIn] = useState(() => !!tokenStorage.get());
+
+  const login = (token: string) => {
+    tokenStorage.set(token);
+    setIsLoggedIn(true);
+  };
+
+  const logout = () => {
+    tokenStorage.remove();
+    setIsLoggedIn(false);
+  };
+
+  return (
+    <AuthContext.Provider value={{ isLoggedIn, login, logout }}>{children}</AuthContext.Provider>
+  );
+};
+
+// eslint-disable-next-line react-refresh/only-export-components
+export const useAuth = () => {
+  const context = useContext(AuthContext);
+  if (!context) {
+    throw new Error('useAuth는 AuthProvider 내에서 사용해야 합니다.');
+  }
+  return context;
+};

--- a/src/features/auth/ui/login-widget.css.ts
+++ b/src/features/auth/ui/login-widget.css.ts
@@ -1,0 +1,75 @@
+import { style } from '@vanilla-extract/css';
+
+import { themeVars } from '@/shared/styles/theme.css';
+import { typography } from '@/shared/styles/typography.css';
+
+export const container = style({
+  display: 'flex',
+  flexDirection: 'column',
+  alignItems: 'center',
+  justifyContent: 'center',
+  minHeight: '100vh',
+  gap: '2.4rem',
+  padding: '0 2rem',
+});
+
+export const title = style({
+  ...typography.h4_bd_24,
+  color: themeVars.color.grayscale.white,
+  marginBottom: '1.6rem',
+});
+
+export const errorMessage = style({
+  ...typography.body3_bd_18,
+  color: themeVars.color.error.red_100,
+  marginBottom: '0.8rem',
+});
+
+export const buttonGroup = style({
+  display: 'flex',
+  flexDirection: 'column',
+  gap: '1.2rem',
+  width: '100%',
+  maxWidth: '40rem',
+});
+
+export const socialButton = style({
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+  gap: '1rem',
+  width: '100%',
+  padding: '1.6rem',
+  borderRadius: '10px',
+  border: 'none',
+  cursor: 'pointer',
+  ...typography.body2_bd_20,
+  transition: 'opacity 0.2s ease-in-out',
+  ':hover': {
+    opacity: 0.85,
+  },
+});
+
+export const kakaoButton = style([
+  socialButton,
+  {
+    backgroundColor: '#FEE500',
+    color: themeVars.color.grayscale.black,
+  },
+]);
+
+export const googleButton = style([
+  socialButton,
+  {
+    backgroundColor: themeVars.color.grayscale.white,
+    color: themeVars.color.grayscale.black,
+  },
+]);
+
+export const naverButton = style([
+  socialButton,
+  {
+    backgroundColor: '#03C75A',
+    color: themeVars.color.grayscale.white,
+  },
+]);

--- a/src/features/auth/ui/login-widget.tsx
+++ b/src/features/auth/ui/login-widget.tsx
@@ -1,0 +1,44 @@
+import * as styles from './login-widget.css';
+
+type SocialProvider = 'kakao' | 'google' | 'naver';
+
+const BASE_URL = import.meta.env.VITE_API_BASE_URL as string;
+
+const SOCIAL_PROVIDERS: { provider: SocialProvider; label: string; className: string }[] = [
+  { provider: 'kakao', label: '카카오로 로그인', className: styles.kakaoButton },
+  { provider: 'google', label: 'Google로 로그인', className: styles.googleButton },
+  { provider: 'naver', label: '네이버로 로그인', className: styles.naverButton },
+];
+
+const handleSocialLogin = (provider: SocialProvider) => {
+  window.location.href = `${BASE_URL}/oauth2/authorize/${provider}`;
+};
+
+interface LoginWidgetProps {
+  hasError?: boolean;
+}
+
+const LoginWidget = ({ hasError = false }: LoginWidgetProps) => {
+  return (
+    <div className={styles.container}>
+      <h1 className={styles.title}>BOAZ 로그인</h1>
+      {hasError && (
+        <p className={styles.errorMessage}>로그인에 실패했습니다. 다시 시도해 주세요.</p>
+      )}
+      <div className={styles.buttonGroup}>
+        {SOCIAL_PROVIDERS.map(({ provider, label, className }) => (
+          <button
+            key={provider}
+            type="button"
+            className={className}
+            onClick={() => handleSocialLogin(provider)}
+          >
+            {label}
+          </button>
+        ))}
+      </div>
+    </div>
+  );
+};
+
+export default LoginWidget;

--- a/src/pages/auth-callback-page.tsx
+++ b/src/pages/auth-callback-page.tsx
@@ -1,0 +1,26 @@
+import { useEffect } from 'react';
+import { useNavigate } from 'react-router';
+
+import { useAuth } from '@/features/auth/model/auth-context';
+import { ROUTE_PATH } from '@/shared/router/paths';
+
+const AuthCallbackPage = () => {
+  const navigate = useNavigate();
+  const { login } = useAuth();
+
+  useEffect(() => {
+    const params = new URLSearchParams(window.location.hash.substring(1));
+    const token = params.get('token');
+
+    if (token) {
+      login(token);
+      window.history.replaceState({}, '', ROUTE_PATH.HOME);
+    }
+
+    navigate(ROUTE_PATH.HOME, { replace: true });
+  }, [login, navigate]);
+
+  return null;
+};
+
+export default AuthCallbackPage;

--- a/src/pages/login-page.tsx
+++ b/src/pages/login-page.tsx
@@ -1,0 +1,12 @@
+import { useSearchParams } from 'react-router';
+
+import LoginWidget from '@/features/auth/ui/login-widget';
+
+const LoginPage = () => {
+  const [searchParams] = useSearchParams();
+  const hasError = searchParams.get('error') === 'true';
+
+  return <LoginWidget hasError={hasError} />;
+};
+
+export default LoginPage;

--- a/src/shared/api/client.ts
+++ b/src/shared/api/client.ts
@@ -1,10 +1,84 @@
 import axios from 'axios';
 
+import { tokenStorage } from '@/shared/auth/token-storage';
+
 const BASE_URL = import.meta.env.VITE_API_BASE_URL;
 
 export const instance = axios.create({
   baseURL: BASE_URL,
+  withCredentials: true,
 });
+
+instance.interceptors.request.use((config) => {
+  const token = tokenStorage.get();
+  if (token) {
+    config.headers['Authorization'] = `Bearer ${token}`;
+  }
+  return config;
+});
+
+let isRefreshing = false;
+let pendingQueue: Array<{
+  resolve: (token: string) => void;
+  reject: (error: unknown) => void;
+}> = [];
+
+const flushQueue = (token: string | null, error: unknown = null) => {
+  pendingQueue.forEach(({ resolve, reject }) => {
+    if (token) {
+      resolve(token);
+    } else {
+      reject(error);
+    }
+  });
+  pendingQueue = [];
+};
+
+instance.interceptors.response.use(
+  (response) => response,
+  async (error) => {
+    const originalRequest = error.config;
+
+    const isAuthEndpoint =
+      originalRequest.url?.includes('/auth/user/refresh') ||
+      originalRequest.url?.includes('/auth/user/logout');
+
+    if (error.response?.status === 401 && !originalRequest._retry && !isAuthEndpoint) {
+      originalRequest._retry = true;
+
+      if (isRefreshing) {
+        return new Promise((resolve, reject) => {
+          pendingQueue.push({ resolve, reject });
+        }).then((token) => {
+          originalRequest.headers['Authorization'] = `Bearer ${token}`;
+          return instance(originalRequest);
+        });
+      }
+
+      isRefreshing = true;
+
+      try {
+        const response = await instance.post<{ data: { access_token: string } }>(
+          '/api/v1/auth/user/refresh'
+        );
+        const newToken = response.data.data.access_token;
+        tokenStorage.set(newToken);
+        flushQueue(newToken);
+        originalRequest.headers['Authorization'] = `Bearer ${newToken}`;
+        return instance(originalRequest);
+      } catch (refreshError) {
+        flushQueue(null, refreshError);
+        tokenStorage.remove();
+        window.location.href = '/login';
+        return Promise.reject(refreshError);
+      } finally {
+        isRefreshing = false;
+      }
+    }
+
+    return Promise.reject(error);
+  }
+);
 
 export const get = async <T>(...args: Parameters<typeof instance.get>): Promise<T> => {
   const response = await instance.get<{ data: T }>(...args);

--- a/src/shared/api/end-point.ts
+++ b/src/shared/api/end-point.ts
@@ -1,4 +1,8 @@
 export const END_POINT = {
+  AUTH: {
+    REFRESH: 'api/v1/auth/user/refresh',
+    LOGOUT: 'api/v1/auth/user/logout',
+  },
   RECRUITMENT: {
     GET_STATUS: 'api/v1/recruitment/status',
     GET_DETAIL: 'api/v1/recruitment/{term}',

--- a/src/shared/auth/token-storage.ts
+++ b/src/shared/auth/token-storage.ts
@@ -1,0 +1,7 @@
+const ACCESS_TOKEN_KEY = 'access_token';
+
+export const tokenStorage = {
+  get: () => localStorage.getItem(ACCESS_TOKEN_KEY),
+  set: (token: string) => localStorage.setItem(ACCESS_TOKEN_KEY, token),
+  remove: () => localStorage.removeItem(ACCESS_TOKEN_KEY),
+};

--- a/src/shared/router/paths.ts
+++ b/src/shared/router/paths.ts
@@ -4,7 +4,9 @@ export const ROUTE_PATH = {
   RECRUITING: '/recruiting',
   ARCHIVE: '/archive',
   FAQ: '/faq',
-  APPLY: '/apply', // 페이지 추가
+  APPLY: '/apply',
+  LOGIN: '/login',
+  AUTH_CALLBACK: '/auth/callback',
 } as const;
 
 export type Routes = (typeof ROUTE_PATH)[keyof typeof ROUTE_PATH];

--- a/src/shared/router/protected-route.tsx
+++ b/src/shared/router/protected-route.tsx
@@ -1,0 +1,16 @@
+import { Navigate, Outlet } from 'react-router';
+
+import { useAuth } from '@/features/auth/model/auth-context';
+import { ROUTE_PATH } from '@/shared/router/paths';
+
+const ProtectedRoute = () => {
+  const { isLoggedIn } = useAuth();
+
+  if (!isLoggedIn) {
+    return <Navigate to={ROUTE_PATH.LOGIN} replace />;
+  }
+
+  return <Outlet />;
+};
+
+export default ProtectedRoute;

--- a/src/shared/router/router.tsx
+++ b/src/shared/router/router.tsx
@@ -1,6 +1,8 @@
 import { createBrowserRouter } from 'react-router';
 
 import { GlobalLayout } from '@/app/layouts/global-layout/global-layout';
+import AuthCallbackPage from '@/pages/auth-callback-page';
+import LoginPage from '@/pages/login-page';
 import {
   ApplyPage,
   ArchivePage,
@@ -10,6 +12,8 @@ import {
   RecruitingPage,
 } from '@/shared/router/lazy';
 import { ROUTE_PATH } from '@/shared/router/paths';
+
+import ProtectedRoute from './protected-route';
 
 export const router = createBrowserRouter([
   {
@@ -36,9 +40,22 @@ export const router = createBrowserRouter([
         Component: FAQPage,
       },
       {
-        path: ROUTE_PATH.APPLY,
-        Component: ApplyPage,
+        Component: ProtectedRoute,
+        children: [
+          {
+            path: ROUTE_PATH.APPLY,
+            Component: ApplyPage,
+          },
+        ],
       },
     ],
+  },
+  {
+    path: ROUTE_PATH.LOGIN,
+    Component: LoginPage,
+  },
+  {
+    path: ROUTE_PATH.AUTH_CALLBACK,
+    Component: AuthCallbackPage,
   },
 ]);

--- a/tsconfig.app.json
+++ b/tsconfig.app.json
@@ -24,7 +24,6 @@
     "noFallthroughCasesInSwitch": true,
     "noUncheckedSideEffectImports": true,
 
-    "baseUrl": ".",
     "paths": {
       "@/*": ["./src/*"]
     }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -18,14 +18,13 @@
     "noUnusedParameters": true,
     "noFallthroughCasesInSwitch": true,
 
-    "baseUrl": ".",
     "paths": {
-      "@/app/*": ["src/app/*"],
-      "@/pages/*": ["src/pages/*"],
-      "@/widgets/*": ["src/widgets/*"],
-      "@/entities/*": ["src/entities/*"],
-      "@/features/*": ["src/features/*"],
-      "@/shared/*": ["src/shared/*"]
+      "@/app/*": ["./src/app/*"],
+      "@/pages/*": ["./src/pages/*"],
+      "@/widgets/*": ["./src/widgets/*"],
+      "@/entities/*": ["./src/entities/*"],
+      "@/features/*": ["./src/features/*"],
+      "@/shared/*": ["./src/shared/*"]
     }
   },
   "files": [],


### PR DESCRIPTION
## 📌 Summary

- Resolves: #102

## 📚 Tasks

- 구글, 네이버, 카카오 소셜 로그인 구현 (`/login` 페이지 ui 구현)
- OAuth 콜백 처리 구현 (`/auth/callback` 페이지)
  - URL Fragment(`#token=...`)에서 Access Token 파싱 후 localStorage 저장
- 전역 Auth 상태 관리 (`AuthContext`, `useAuth`)
- Axios 인터셉터 추가
  - 요청 시 `Authorization: Bearer {token}` 헤더 주입
  - 401 응답 시 `POST /api/v1/auth/user/refresh` 호출 후 원래 요청 자동 재시도
  - Refresh Token도 만료된 경우 토큰 삭제 후 `/login` 리다이렉트
- 로그아웃 API 연동 (`POST /api/v1/auth/user/logout`)
- `/apply` Protected Route 추가 →  미로그인 사용자는 `/login`으로 리다이렉트되도록

## 👀 To Reviewer

- Access Token은 `localStorage`, Refresh Token은 `HttpOnly 쿠키`로 관리합니다. 쿠키는 서버에서 설정하며 프론트에서는 별도 처리 없이 `withCredentials: true`로 자동 전송하는 구조예요
- 로컬 개발 환경 테스트 시 백엔드의 OAuth 성공 redirect URL이 `prod-www.bigdataboaz.com`으로 설정되어 있어서 테스트 불가능합니다!
- 디자인이 없어서 임시로 구현해두었으니 참고 부탁드려요!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * 소셜 로그인 기능 추가 (카카오, 구글, 네이버)
  * 인증 상태 관리 및 자동 토큰 갱신 기능
  * 로그인 페이지 및 인증 콜백 페이지 추가
  * 인증이 필요한 페이지에 대한 자동 리다이렉트
  * 로그아웃 기능 구현

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/BOAZ-website/frontend/pull/103?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->