### PR TITLE
[Fix] 리프레시 요청 Authorization 헤더 제거

### DIFF
--- a/src/shared/api/client.ts
+++ b/src/shared/api/client.ts
@@ -10,8 +10,9 @@ export const instance = axios.create({
 });
 
 instance.interceptors.request.use((config) => {
+  const isRefreshEndpoint = config.url?.includes('/auth/user/refresh');
   const token = tokenStorage.get();
-  if (token) {
+  if (token && !isRefreshEndpoint) {
     config.headers['Authorization'] = `Bearer ${token}`;
   }
   return config;


### PR DESCRIPTION
## 📌 Summary

<!-- 관련 Issue를 태그해주세요 -->
<!-- #뒤에 이슈넘버 써주시면 자동으로 이슈페이지 연결이 됩니다 ! -->

- Resolves: #138

## 📚 Tasks

<!-- 작업한 부분에 대한 내용을 써주세요 -->

- 리프레시 엔드포인트는 쿠키의 refresh token만 필요한데, 만료된 access token이 Authorization 헤더에 같이 실려서 15분이 지나면 로그아웃 되는 문제가 있었어요

## 👀 To Reviewer

<!--
(기재 내용 없을 경우 섹션 삭제)
더 전달할 내용 혹은 리뷰에게 요청하는 내용을 작성해주세요.
-->

```
흐름:
1. 15분 후 액세스 토큰 만료
2. API 요청 → 401 응답
3. 응답 인터셉터 → 리프레시 요청 실행
4. instance.post('/api/v1/auth/user/refresh') 호출
5. ← 요청 인터셉터가 또 실행됨 (line 12-18)
6. Authorization: Bearer <만료된 토큰> 을 refresh 요청에도 추가!
7. 서버가 만료된 토큰을 보고 refresh 요청 거부 → 401
8. 토큰 삭제 + 로그아웃
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * 토큰 새로고침 요청에 대한 인증 헤더 처리 로직을 개선했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->