### PR TITLE
fix: Safari에서 아카이브 필터 깨짐 수정

### DIFF
--- a/src/pages/archive-page.css.ts
+++ b/src/pages/archive-page.css.ts
@@ -97,6 +97,7 @@ export const filterGroup = style({
   display: 'flex',
   gap: '0.8rem',
   alignItems: 'center',
+  flexShrink: 0,
 });
 
 export const cardGrid = style({

--- a/src/shared/components/accordion/accordion.css.ts
+++ b/src/shared/components/accordion/accordion.css.ts
@@ -10,6 +10,7 @@ import { typography } from '@/shared/styles/typography.css';
 const TRANSITION = `${ACCORDION_DURATION_MS}ms ease`;
 
 export const itemStyle = style({
+  width: '100%',
   borderBottom: `0.5px solid ${themeVars.color.grayscale[400]}`,
 });
 

--- a/src/shared/components/accordion/accordion.css.ts
+++ b/src/shared/components/accordion/accordion.css.ts
@@ -18,6 +18,7 @@ export const questionStyle = style({
   display: 'flex',
   justifyContent: 'space-between',
   alignItems: 'center',
+  gap: '1.2rem',
   padding: '3.9rem 2.4rem 3.9rem 0',
   color: themeVars.color.grayscale.white,
   '@media': {
@@ -30,6 +31,7 @@ export const questionStyle = style({
 export const questionText = recipe({
   base: {
     ...typography.body3_bd_18,
+    flex: 1,
     color: themeVars.color.grayscale.white,
     transition: `color ${TRANSITION}`,
     '@media': {

--- a/src/shared/components/accordion/accordion.css.ts
+++ b/src/shared/components/accordion/accordion.css.ts
@@ -32,6 +32,7 @@ export const questionText = recipe({
   base: {
     ...typography.body3_bd_18,
     flex: 1,
+    textAlign: 'left',
     color: themeVars.color.grayscale.white,
     transition: `color ${TRANSITION}`,
     '@media': {

--- a/src/shared/components/accordion/accordion.tsx
+++ b/src/shared/components/accordion/accordion.tsx
@@ -19,7 +19,7 @@ const Accordion = ({ trigger, children }: AccordionProps) => {
     <div className={styles.itemStyle}>
       <button type="button" className={styles.questionStyle} onClick={toggle}>
         <span className={styles.questionText({ open: isOpen })}>{trigger}</span>
-        <Icon width={16} height={16} />
+        <Icon width={16} height={16} style={{ flexShrink: 0 }} />
       </button>
 
       <div className={styles.answerWrapper({ open: isOpen })}>

--- a/src/shared/components/fixed-tab/fixed-tab.css.ts
+++ b/src/shared/components/fixed-tab/fixed-tab.css.ts
@@ -25,8 +25,9 @@ export const fixedTab = recipe({
     color: themeVars.color.grayscale.black,
     '@media': {
       [media.mobile]: {
-        width: '10rem',
-        padding: '1.65rem 2.25rem',
+        width: 'auto',
+        minWidth: '10rem',
+        padding: '1.65rem 1.6rem',
         ...typography.h5_sm_16,
         flexShrink: 0,
         borderRadius: '10px',

--- a/src/widgets/archive/ui/generation-filter/generation-filter.css.ts
+++ b/src/widgets/archive/ui/generation-filter/generation-filter.css.ts
@@ -24,6 +24,8 @@ export const trigger = style({
   height: '4.8rem',
   padding: '0 1.4rem',
   borderRadius: '20px',
+  flexShrink: 0,
+  WebkitAppearance: 'none',
   backgroundColor: themeVars.color.grayscale[900],
   border: `1px solid ${themeVars.color.grayscale[800]}`,
   color: themeVars.color.grayscale.white,

--- a/src/widgets/archive/ui/track-filter/track-filter.css.ts
+++ b/src/widgets/archive/ui/track-filter/track-filter.css.ts
@@ -26,6 +26,8 @@ export const trigger = style({
   padding: '0 1.4rem',
   borderRadius: '20px',
   width: 'fit-content',
+  flexShrink: 0,
+  WebkitAppearance: 'none',
   backgroundColor: themeVars.color.grayscale[900],
   border: `1px solid ${themeVars.color.grayscale[800]}`,
   color: themeVars.color.grayscale.white,

--- a/src/widgets/archive/ui/track-filter/track-filter.tsx
+++ b/src/widgets/archive/ui/track-filter/track-filter.tsx
@@ -41,9 +41,10 @@ const TrackFilterOverlay = ({ value, onChange }: TrackFilterOverlayProps) => {
       const rect = containerRef.current.getBoundingClientRect();
       const rootFontSize = parseFloat(getComputedStyle(document.documentElement).fontSize);
       const gap = isMobile ? 1 * rootFontSize : 3.8 * rootFontSize;
+      const viewportWidth = document.documentElement.clientWidth;
       setOverlayPos({
         top: rect.bottom + gap,
-        right: window.innerWidth - rect.right,
+        right: viewportWidth - rect.right,
       });
     }
     setIsOpen((prev) => !prev);

--- a/src/widgets/faq/ui/faq-content-section.css.ts
+++ b/src/widgets/faq/ui/faq-content-section.css.ts
@@ -74,9 +74,11 @@ export const tabVariants = styleVariants({
 
 export const listSection = style({
   flex: 1,
+  width: '100%',
 });
 
 export const accordionContainer = style({
   display: 'flex',
   flexDirection: 'column',
+  width: '100%',
 });


### PR DESCRIPTION
- TrackFilter: window.innerWidth → document.documentElement.clientWidth로 교체해 Safari visual/layout viewport 불일치 해소
- filterGroup, 각 트리거 버튼에 flexShrink: 0 추가해 좁은 화면에서 버튼 찌그러짐 방지
- 트리거 버튼에 WebkitAppearance: none 추가해 Safari 기본 버튼 스타일 제거

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Style**
  * 레이아웃 안정성 개선: 필터, 아코디언, 탭 등 주요 UI 요소의 레이아웃 축소 동작을 제어하여 화면 크기 변화에 더 안정적으로 대응합니다.
  * 컴포넌트 간격 및 너비 조정: 아코디언, FAQ 섹션의 간격과 너비를 최적화하여 시각적 일관성을 개선합니다.

* **Bug Fixes**
  * 오버레이 위치 계산 정확도 개선: 모바일 환경에서 필터 오버레이 위치가 더 정확하게 표시됩니다.
  * 크로스 브라우저 호환성 개선: WebKit 기반 브라우저에서의 버튼 표시 방식을 통일합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->