### PR TITLE
[Add] Footer에 개인정보처리방침(/privacy) 링크 추가

### DIFF
--- a/public/landing.html
+++ b/public/landing.html
@@ -1529,6 +1529,14 @@
         line-height: 1.4;
       }
 
+      .landing-footer-privacy-link {
+        color: #999999;
+        font-size: 16px;
+        font-weight: 400;
+        line-height: 1.4;
+        text-decoration: underline;
+      }
+
       @media (max-width: 768px) {
         .activity-shell {
           grid-template-columns: 1fr;
@@ -2455,6 +2463,9 @@
             width="122"
             height="18"
           />
+          <a class="landing-footer-privacy-link" href="/privacy" target="_parent"
+            >개인정보처리방침</a
+          >
           <small class="landing-footer-copyright">© 2026 BOAZ. All rights reserved.</small>
         </section>
         <section class="landing-footer-column">
@@ -2618,6 +2629,7 @@
             </a>
           </li>
         </ul>
+        <a class="landing-footer-privacy-link" href="/privacy" target="_parent">개인정보처리방침</a>
         <small class="landing-footer-copyright">© 2026 BOAZ. All rights reserved.</small>
       </div>
     </footer>

--- a/src/widgets/common/ui/footer/footer.css.ts
+++ b/src/widgets/common/ui/footer/footer.css.ts
@@ -104,3 +104,9 @@ export const copyright = style({
   ...typography.body5_rg_16,
   color: themeVars.color.grayscale[400],
 });
+
+export const privacyLink = style({
+  ...typography.body5_rg_16,
+  color: themeVars.color.grayscale[400],
+  textDecoration: 'underline',
+});

--- a/src/widgets/common/ui/footer/footer.tsx
+++ b/src/widgets/common/ui/footer/footer.tsx
@@ -1,10 +1,12 @@
 import { useEffect, useState } from 'react';
+import { Link } from 'react-router';
 
 import HSpaceLogo from '@/shared/assets/icons/hspace_logo.svg?react';
 import InstagramIcon from '@/shared/assets/icons/ic_instagram.svg?react';
 import MediumIcon from '@/shared/assets/icons/ic_medium.svg?react';
 import SlideShareIcon from '@/shared/assets/icons/ic_slideshare.svg?react';
 import YouTubeIcon from '@/shared/assets/icons/ic_youtube.svg?react';
+import { ROUTE_PATH } from '@/shared/router/paths';
 
 import * as styles from './footer.css';
 
@@ -44,6 +46,9 @@ const Footer = () => {
               </li>
             ))}
           </ul>
+          <Link className={styles.privacyLink} to={ROUTE_PATH.PRIVACY}>
+            개인정보처리방침
+          </Link>
           <small className={styles.copyright}>© 2026 BOAZ. All rights reserved.</small>
         </div>
       </footer>
@@ -55,6 +60,9 @@ const Footer = () => {
       <div className={styles.desktopInner}>
         <section className={styles.col.left}>
           <HSpaceLogo width={122} height={18} />
+          <Link className={styles.privacyLink} to={ROUTE_PATH.PRIVACY}>
+            개인정보처리방침
+          </Link>
           <small className={styles.copyright}>© 2026 BOAZ. All rights reserved.</small>
         </section>
         <section className={styles.col.center}>


### PR DESCRIPTION
## 📌 Summary

<!-- 관련 Issue를 태그해주세요 -->
<!-- #뒤에 이슈넘버 써주시면 자동으로 이슈페이지 연결이 됩니다 ! -->

- Resolves: #190

## 📚 Tasks

<!-- 작업한 부분에 대한 내용을 써주세요 -->

- 구글 소셜 로그인 승인 심사에서, 메인 페이지로부터 /privacy 페이지에 접근할 수 있는 경로가 필요하다는 피드백을 받아서 개인정보처리방침 링크를 푸터에 노출하도록 적용했습니다 (스크린샷 참고)
마찬가지로 단일 landing.html 파일에도 같은 스타일을 적용해서 추가해두었습니다

## 📸 Screenshot

<!--
(기재 내용 없을 경우 섹션 삭제)
UI 변경사항이 있는 경우 스크린샷을 첨부해주세요.
동적인 변화는 GIF로 첨부하면 더 좋습니다!
-->

**데스크탑 뷰**: 왼쪽 로고 아래, 저작권 문구 위
<img width="723" height="128" alt="image" src="https://github.com/user-attachments/assets/4592b89e-f278-43c0-a927-94d77ad825f5" />

**모바일 뷰**: SNS 목록 아래, 저작권 문구 위
<img width="321" height="169" alt="image" src="https://github.com/user-attachments/assets/be062eaa-c866-494d-9af1-4014839347ba" />
